### PR TITLE
Fix: 'child' widget with a large width collides with toggle icon

### DIFF
--- a/lib/src/action_slider_widget.dart
+++ b/lib/src/action_slider_widget.dart
@@ -504,8 +504,12 @@ class ActionSlider extends StatefulWidget {
         : Alignment.centerRight;
     return Padding(
       padding: EdgeInsets.only(
-        left: state.toggleSize.height,
-        right: state.toggleSize.height,
+        left: state.direction == TextDirection.rtl
+            ? state.toggleSize.height / 2
+            : state.toggleSize.height,
+        right: state.direction == TextDirection.rtl
+            ? state.toggleSize.height
+            : state.toggleSize.height / 2,
       ),
       child: ClipRect(
         child: OverflowBox(

--- a/lib/src/action_slider_widget.dart
+++ b/lib/src/action_slider_widget.dart
@@ -905,7 +905,8 @@ class _ActionSliderState extends State<ActionSlider>
           builder: (context, child) {
             final width = maxWidth - (_loadingAnimation.value * standardWidth);
             final backgroundWidth =
-                width - widget.toggleWidth - widget.toggleMargin.horizontal;
+                (width - widget.toggleWidth - widget.toggleMargin.horizontal)
+                    .abs();
             double statePosToLocalPos(double statePos) =>
                 (statePos * backgroundWidth).clamp(0.0, backgroundWidth);
             final position = statePosToLocalPos(_state.position);

--- a/lib/src/action_slider_widget.dart
+++ b/lib/src/action_slider_widget.dart
@@ -504,8 +504,8 @@ class ActionSlider extends StatefulWidget {
         : Alignment.centerRight;
     return Padding(
       padding: EdgeInsets.only(
-        left: state.toggleSize.height / 2,
-        right: state.toggleSize.height / 2,
+        left: state.toggleSize.height,
+        right: state.toggleSize.height,
       ),
       child: ClipRect(
         child: OverflowBox(


### PR DESCRIPTION
The 'child' widget, which is the widget displayed on the background, with a large width collides with toggle icon (visually). And is centered based on the whole action slider rather than the empty part of the slider.